### PR TITLE
First attempt at outputing info for Argos (and BitBar)

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -164,3 +164,34 @@ def list_issuers(ep, nbr, last):
         sorted_list = sorted(list_issued, key=itemgetter("blocks"), reverse=True)
         print("from {0} issuers\n{1}".format(len(list_issued),
         tabulate(sorted_list, headers="keys", tablefmt="orgtbl", floatfmt=".1f", stralign="center")))
+
+def argos_info(ep):
+    info_type = ["newcomers", "certs", "actives", "leavers", "excluded", "ud", "tx"]
+    pretty_names = {'g1': 'Ğ1', 'gtest': 'Ğtest'}
+    i, info_data = 0, dict()
+    while (i < len(info_type)):
+            info_data[info_type[i]] = request(ep, "blockchain/with/" + info_type[i])["result"]["blocks"]
+            i +=1
+    current = get_current_block(ep)
+    pretty = current["currency"]
+    if current["currency"] in pretty_names:
+        pretty = pretty_names[current["currency"]]
+    print(pretty, "|")
+    print("---")
+    href = 'href=http://%s:%s/' % (ep[best_node(ep, 1)], ep["port"])
+    print("Connected to node:", ep[best_node(ep, 1)], ep["port"], "|", href,
+    "\nCurrent block number:", current["number"],
+    "\nCurrency name:", current["currency"],
+    "\nNumber of members:", current["membersCount"],
+    "\nMinimal Proof-of-Work:", current["powMin"],
+    "\nCurrent time:", convert_time(current["time"], "all"),
+    "\nMedian time:", convert_time(current["medianTime"], "all"),
+    "\nDifference time:", convert_time(current["time"] - current["medianTime"], "hour"),
+    "\nNumber of blocks containing… \
+     \n-- new comers:", len(info_data["newcomers"]),
+    "\n-- Certifications:", len(info_data["certs"]),
+    "\n-- Actives (members updating their membership):", len(info_data["actives"]),
+    "\n-- Leavers:", len(info_data["leavers"]),
+    "\n-- Excluded:", len(info_data["excluded"]),
+    "\n-- UD created:", len(info_data["ud"]),
+    "\n-- transactions:", len(info_data["tx"]))

--- a/src/silkaj.py
+++ b/src/silkaj.py
@@ -9,7 +9,7 @@ from commands import *
 def cli():
     # ep: endpoint, node's network interface
     ep, c = dict(), Command()
-    subcmd = ["info", "diffi", "network", "issuers"]
+    subcmd = ["info", "diffi", "network", "issuers", "argos"]
     if c.is_help_request() or c.is_usage_request() or c.subcmd not in subcmd: usage(); exit()
     if c.is_version_request(): print("silkaj 0.1.0"); exit()
     ep["domain"], ep["port"] = "duniter.org", "10901"
@@ -29,6 +29,8 @@ def manage_cmd(ep, c):
         network_info(ep, c.contains_switches("discover"))
     elif c.subcmd == "issuers" and c.subsubcmd and int(c.subsubcmd) >= 0:
         list_issuers(ep, int(c.subsubcmd), c.contains_switches('last'))
+    elif c.subcmd == "argos":
+       argos_info(ep)
 
 def usage():
     print("Silkaj: command line Duniter client \
@@ -41,6 +43,7 @@ def usage():
     \n  - `--discover` option to discover all network (could take a while) \
     \n - issuers n: display last n issuers (`0` for all blockchain) \
     \n  - last issuers are displayed under n ≤ 30. To force display last ones, use `--last` option \
+    \n - argos: display information about currency formated for Argos or BitBar \
     \ncustom endpoint with option `-p` and <domain>:<port>")
     exit()
 


### PR DESCRIPTION
This adds an 'argos' subcommand that outputs the same as 'info' but formated for use by Argos, a GNOME-Shell extension that is a compatible with MacOS' BitBar. Result looks [like this](https://pod.g3l.org/posts/172210).

One just needs to add a (executable) `.config/argos/silkaj.10m.sh`:
```bash
#!/usr/bin/env bash
/path/to/silkaj argos
```