### PR TITLE
[enh] #27: add transaction prompt confirmation with tx summary.

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -212,7 +212,10 @@ def cmd_transaction(ep, c):
     else:
         outputBackChange = None
         
-    generate_and_send_transaction(ep, seed, amount, output, comment, allSources, outputBackChange)
+    if c.contains_switches('yes') or c.contains_switches('y') or \
+            input("Do you confirm sending {} {} from {} to {} with \"{}\" as comment? [yes/no]: "\
+            .format(amount, get_current_block(ep)["currency"], get_publickey_from_seed(seed), output, comment)) == "yes":
+        generate_and_send_transaction(ep, seed, amount, output, comment, allSources, outputBackChange)
 
 
 def show_amount_from_pubkey(ep, pubkey):

--- a/src/silkaj.py
+++ b/src/silkaj.py
@@ -27,6 +27,7 @@ def usage():
     \n     [--comment=<comment>] \
     \n     [--allSources] \
     \n     [--outputBackChange=<public key[:checksum]>] \
+    \n     -y | --yes, don't ask for prompt confirmation \
     \n \
     \n - network: Display current network with many information \
     \n      --discover     Discover all network (could take a while) \


### PR DESCRIPTION
- add `-y` and `--yes` options for automated transactions to bypass this prompt.