### PR TITLE
[fix] network sort: integer value were sorted as strings.

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -90,7 +90,7 @@ def get_network_sort_key(endpoint):
     t = list()
     for akey in network_sort_keys:
         if akey == 'diffi' or akey == 'block' or akey == 'port':
-            t.append(endpoint[akey] if akey in endpoint else 0)
+            t.append(int(endpoint[akey]) if akey in endpoint else 0)
         else:
             t.append(str(endpoint[akey]) if akey in endpoint else "")
     return tuple(t)


### PR DESCRIPTION
numbers must be sorted as `int()`.
It is not working with `port`:
```bash
|       cgeek.fr        |  10900 |
|   gtest3.elois.org    |  10900 |
|   gtest.duniter.org   |  10900 |
|                       |  30398 |
|   copper.jellium.io   |    443 |
| …st.duniter.tednet.fr |   8888 |
|  duniter.grohub.org   |   8999 |
```