### PR TITLE
Add 'wot' subcmd to display received and sent certifications

### DIFF
--- a/src/silkaj.py
+++ b/src/silkaj.py
@@ -5,6 +5,7 @@ import sys
 
 from commandlines import Command
 from commands import *
+from wot import *
 
 
 def usage():
@@ -52,14 +53,16 @@ def usage():
     \n      --auth-seed | --auth-file [--file=<path file>] | --auth-wif\
     \n \
     \n - id <pubkey> or <identity>: get corresponding identity or pubkey from pubkey or identity.\
-    \n      it could autocomplete the pubkey corresponding to an identity with three or four following characters.")
+    \n      it could autocomplete the pubkey corresponding to an identity with three or four following characters.\
+    \n \
+    \n - wot <pubkey> or <identity>: display received and sent certifications for an account.")
     sys.exit()
 
 
 def cli():
     # ep: endpoint, node's network interface
     ep, c = dict(), Command()
-    subcmd = ["info", "diffi", "network", "issuers", "argos", "amount", "transaction", "generate_auth_file", "id"]
+    subcmd = ["info", "diffi", "network", "issuers", "argos", "amount", "transaction", "generate_auth_file", "id", "wot"]
     if c.is_version_request():
         print("silkaj 0.3.0")
         sys.exit()
@@ -107,6 +110,9 @@ def manage_cmd(ep, c):
 
     elif c.subcmd == "id":
         id_pubkey_correspondence(ep, c.subsubcmd)
+
+    elif c.subcmd == "wot":
+        received_sent_certifications(ep, c.subsubcmd)
 
 
 if __name__ == '__main__':

--- a/src/wot.py
+++ b/src/wot.py
@@ -2,8 +2,8 @@ import os
 from tabulate import tabulate
 from collections import OrderedDict
 
-from network_tools import *
-from tools import *
+from network_tools import request
+from tools import get_pubkeys_from_id
 from constants import *
 
 

--- a/src/wot.py
+++ b/src/wot.py
@@ -1,0 +1,34 @@
+import os
+from tabulate import tabulate
+from collections import OrderedDict
+
+from network_tools import *
+from tools import *
+from constants import *
+
+
+def received_sent_certifications(ep, id):
+    """
+    check id exist
+    many identities could exist
+    retrieve the one searched
+    get id of received and sent certifications
+    display on a chart the result with the numbers
+    """
+    if get_pubkeys_from_id(ep, id) == NO_MATCHING_ID:
+        print(NO_MATCHING_ID)
+        sys.exit(1)
+    certs = request(ep, "wot/lookup/" + id)["results"]
+    for cert in certs:
+        if cert["uids"][0]["uid"].lower() == id.lower():
+           certs = cert
+    certifications = OrderedDict()
+    certifications["received"] = list()
+    certifications["sent"] = list()
+    for received, cert in enumerate(certs["uids"][0]["others"]):
+        certifications["received"].append(cert["uids"][0])
+    for sent, cert in enumerate(certs["signed"]):
+        certifications["sent"].append(cert["uid"])
+    os.system("clear")
+    print("{0} received {1} and sent {2} certifications:\n{3}"
+    .format(id, received, sent, tabulate(certifications, headers="keys", tablefmt="orgtbl", stralign="center")))

--- a/src/wot.py
+++ b/src/wot.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from tabulate import tabulate
 from collections import OrderedDict
 

--- a/src/wot.py
+++ b/src/wot.py
@@ -21,14 +21,17 @@ def received_sent_certifications(ep, id):
     certs = request(ep, "wot/lookup/" + id)["results"]
     for cert in certs:
         if cert["uids"][0]["uid"].lower() == id.lower():
-           certs = cert
+            certs = cert
     certifications = OrderedDict()
     certifications["received"] = list()
     certifications["sent"] = list()
-    for received, cert in enumerate(certs["uids"][0]["others"]):
-        certifications["received"].append(cert["uids"][0])
-    for sent, cert in enumerate(certs["signed"]):
-        certifications["sent"].append(cert["uid"])
+    received, sent = 0, 0
+    if certs["uids"]:
+        for received, cert in enumerate(certs["uids"][0]["others"]):
+            certifications["received"].append(cert["uids"][0])
+    if certs["signed"]:
+        for sent, cert in enumerate(certs["signed"]):
+            certifications["sent"].append(cert["uid"])
     os.system("clear")
     print("{0} received {1} and sent {2} certifications:\n{3}"
     .format(id, received, sent, tabulate(certifications, headers="keys", tablefmt="orgtbl", stralign="center")))


### PR DESCRIPTION
```bash
silkaj wot moul
Requested default node: <duniter.org:10901>
moul received 18 and sent 21 certifications:
|    received    |       sent       |
|----------------+------------------|
|   gpsqueeek    |   mathieuBize    |
|  jeanferreira  |      Galuel      |
|    gerard94    |   jeanferreira   |
| BenoitLavenier |     gerard94     |
|      Loda      |      smyds       |
|     smyds      | CaizohanFerreira |
|    fbuland     |    gpsqueeek     |
|     SebasC     |       inso       |
|     Thatoo     |       vit        |
|   cuckooland   |      Thatoo      |
|      inso      |     William      |
|    Paulart     |    cuckooland    |
|   vincentux    |     greyzlii     |
|     Alfybe     |      elois       |
|    urodelus    |      cgeek       |
|    greyzlii    |    PierreYves    |
|   Mententon    |     mmu_man      |
|   PierreYves   |   OlivierAuber   |
|     paidge     |      paidge      |
|                |      Alfybe      |
|                |     1000i100     |
|                |       dig        |
```

I tested with `cgeek`, `inso`, `Galuel`, `jytou` and `Tortue` ids.
I had to fix:
- the fact that `cgeek` gave two results.
- the fact that the check is done with case unsensitive as `Galuel` id is written with uppercase.