### PR TITLE
Wot command refactoring

### DIFF
--- a/src/wot.py
+++ b/src/wot.py
@@ -36,6 +36,7 @@ def received_sent_certifications(ep, id):
             for cert in certs["others"]:
                 certifications["received"].append(cert["uids"][0])
             certifications["sent"] = get_sent_certifications(certs_req)
-            print("{0} from block #{1}\nreceived {2} and sent {3} certifications:\n{4}\n"
-                    .format(id, certs["meta"]["timestamp"][:15], len(certifications["received"]), len(certifications["sent"]),
+            print("{0} ({1}) from block #{2}\nreceived {3} and sent {4} certifications:\n{5}\n"
+                    .format(id, certs_req["pubkey"][:5] + "…", certs["meta"]["timestamp"][:15] + "…",
+                        len(certifications["received"]), len(certifications["sent"]),
                         tabulate(certifications, headers="keys", tablefmt="orgtbl", stralign="center")))


### PR DESCRIPTION
### News
- display charts for identities with same uid
- display the pubkey and their blockstamps
- count number of certifications is now done with `len()` method

---
### Example
It is useful for identities published many times:
```bash
silkaj wot roodinux

roodinux (VxCoq…) from block #32606-0000077F8…
received 2 and sent 0 certifications:
|  received  |  sent  |
|------------+--------|
|  pafzedog  |        |
|    moul    |        |

roodinux (VxCoq…) from block #32777-00000CF74…
received 6 and sent 0 certifications:
|  received  |  sent  |
|------------+--------|
|    moul    |        |
|   RavanH   |        |
|  pafzedog  |        |
|  juandre   |        |
| PierreYves |        |
|   RavanH   |        |

```

### Tests, reviews
- test if it doesn't crash with other identities
- take a look at the code