### PR TITLE
[enh] #46: Add-up pubkeys amounts:

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -218,21 +218,28 @@ def list_issuers(ep, nbr, last):
 
 
 def cmd_amount(ep, c):
-    if c.contains_definitions('pubkey'):
-        pubkey = c.get_definition('pubkey')
-        pubkey = check_public_key(pubkey, True)
-        if not pubkey:
-            return
+    if c.contains_definitions("pubkeys"):
+        pubkeys = c.get_definition("pubkeys").split(":")
+        for pubkey in pubkeys:
+            pubkey = check_public_key(pubkey, True)
+            if not pubkey:
+                return
+        total = [0, 0]
+        for pubkey in pubkeys:
+            value = get_amount_from_pubkey(ep, pubkey)
+            show_amount_from_pubkey(ep, pubkey, value)
+            total[0] += value[0]
+            total[1] += value[1]
+        if (len(pubkeys) > 1):
+            show_amount_from_pubkey(ep, "Total", total)
     else:
         seed = auth_method(c)
         pubkey = get_publickey_from_seed(seed)
+        show_amount_from_pubkey(ep, pubkey, get_amount_from_pubkey(ep, pubkey))
 
-    show_amount_from_pubkey(ep, pubkey)
 
+def show_amount_from_pubkey(ep, pubkey, value):
 
-def show_amount_from_pubkey(ep, pubkey):
-
-    value = get_amount_from_pubkey(ep, pubkey)
     totalAmountInput = value[0]
     amount = value[1]
     # output

--- a/src/silkaj.py
+++ b/src/silkaj.py
@@ -19,8 +19,8 @@ def usage():
     \nCommands: \
     \n - info: Display information about currency \
     \n \
-    \n - amount: Get amount of one account \
-    \n      --pubkey=<pubkey[:checksum]>\
+    \n - amount: Get amount of accounts \
+    \n      --pubkeys=<pubkey:pubkey:pubkey>\
     \n      --auth-scrypt [script parameters -n <N> -r <r> -p <p>] (default: 4096,16,1)\
     \n      --auth-seed | --auth-file [--file=<path file>] | --auth-wif\
     \n \


### PR DESCRIPTION
### Changelog
- retrieve pubkey amounts from outside display f().
- rename argument from "pubkey" –> "pubkeys".
- allows passing many pubkeys as argument.
- display pubkeys amounts in a loop.
- display add-up at the end whether several pubkeys have been specified.

### Example
```bash
silkaj amount --pubkeys GfKERHnJTYzKhKUma5h1uWhetbA8yHKymhVH2raf2aCP:Com8rJukCozHZyFao6AheSsfDQdPApxQRnz7QYFf64mm
pyenv-virtualenv: version `silkaj-env' is already activated
Requested default node: <g1.duniter.org:443>
Total amount of: GfKERHnJTYzKhKUma5h1uWhetbA8yHKymhVH2raf2aCP
----------------------------------------------------------------
Total Relative     = 202.97 UD g1
Total Quantitative = 2031.73 g1

Total amount of: Com8rJukCozHZyFao6AheSsfDQdPApxQRnz7QYFf64mm
----------------------------------------------------------------
Total Relative     = 203.3 UD g1
Total Quantitative = 2034.99 g1

Total amount of: Total
----------------------------------------------------------------
Total Relative     = 406.27 UD g1
Total Quantitative = 4066.72 g1
```
---
Will be merged within the next three days whether or not there is a review.